### PR TITLE
Anonymous listings options, adjust RewriteBase to current root

### DIFF
--- a/server.php
+++ b/server.php
@@ -19,7 +19,7 @@ namespace PicoDAV
 	use KD2\WebDAV\AbstractStorage;
 	use KD2\WebDAV\Exception as WebDAV_Exception;
 
-	class Storage extends AbstractStorageD
+	class Storage extends AbstractStorage
 	{
 		/**
 		 * These file names will be ignored when doing a PUT

--- a/server.php
+++ b/server.php
@@ -549,6 +549,7 @@ namespace PicoDAV
 		public function error(WebDAV_Exception $e)
 		{
 			if ($e->getCode() == 403 && !$this->storage->auth() && count($this->storage->users)) {
+				$this->requireAuth();
 				return;
 			}
 

--- a/server.php
+++ b/server.php
@@ -632,7 +632,10 @@ namespace {
 	$relative_uri = ltrim(substr($uri, strlen($root)), '/');
 
 	if (!empty($_SERVER['SERVER_SOFTWARE']) && stristr($_SERVER['SERVER_SOFTWARE'], 'apache') && !file_exists($self_dir . '/.htaccess')) {
-		file_put_contents($self_dir . '/.htaccess', str_replace('index.php', basename($self), /*__HTACCESS__*/));
+		$content = /*__HTACCESS__*/;
+		$content = str_replace('index.php', basename($self), $content);
+		$content = str_replace('RewriteBase /', rtrim($root, '/') . '/', $content);
+		file_put_contents($self_dir . '/.htaccess', $content);
 	}
 
 	if ($relative_uri == '.webdav/webdav.js' || $relative_uri == '.webdav/webdav.css') {

--- a/server.php
+++ b/server.php
@@ -19,7 +19,7 @@ namespace PicoDAV
 	use KD2\WebDAV\AbstractStorage;
 	use KD2\WebDAV\Exception as WebDAV_Exception;
 
-	class Storage extends AbstractStorage
+	class Storage extends AbstractStorageD
 	{
 		/**
 		 * These file names will be ignored when doing a PUT
@@ -673,6 +673,7 @@ namespace {
 	const DEFAULT_CONFIG = [
 		'ANONYMOUS_READ' => true,
 		'ANONYMOUS_WRITE' => false,
+		'ANONYMOUS_LISTINGS' => true,
 		'HTTP_LOG_FILE' => null,
 	];
 

--- a/server.php
+++ b/server.php
@@ -520,6 +520,10 @@ namespace PicoDAV
 	{
 		protected function html_directory(string $uri, iterable $list): ?string
 		{
+			if (!ANONYMOUS_LISTINGS && !$this->storage->auth()) {
+				throw new WebDAV_Exception('Directory listing is not allowed', 403);
+			}
+
 			$out = parent::html_directory($uri, $list);
 
 			if (null !== $out) {
@@ -527,6 +531,25 @@ namespace PicoDAV
 			}
 
 			return $out;
+		}
+
+		public function http_get(string $uri): ?string
+		{
+			if (!ANONYMOUS_LISTINGS && !$this->storage->auth()) {
+				$props = [];
+				$this->http_head($uri, $props);
+
+				$is_collection = !empty($props['DAV::resourcetype']) && $props['DAV::resourcetype'] == 'collection';
+
+				if ($is_collection) {
+					http_response_code(403);
+					header('Content-Type: text/html; charset=utf-8', true);
+					echo '<h1>403 Forbidden</h1><p>Directory listing is not allowed.</p>';
+					exit;
+				}
+			}
+
+			return parent::http_get($uri);
 		}
 
 		public function route(?string $uri = null): bool
@@ -537,6 +560,19 @@ namespace PicoDAV
 			}
 
 			return parent::route($uri);
+		}
+
+		public function http_propfind(string $uri): ?string
+		{
+			if (!ANONYMOUS_LISTINGS && !$this->storage->auth()) {
+				$depth = isset($_SERVER['HTTP_DEPTH']) && empty($_SERVER['HTTP_DEPTH']) ? 0 : 1;
+
+				if ($depth > 0) {
+					throw new WebDAV_Exception('Directory listing is not allowed for anonymous users', 403);
+				}
+			}
+
+			return parent::http_propfind($uri);
 		}
 
 		protected function requireAuth(): void


### PR DESCRIPTION
Thanks for this neat little project. I made two changes to suit my requirements:

1. A way to deny listings to anonymous users while still allowing direct access to files.
2. Adjust RewriteBase to current root directory.

This is not tested, just copy pasted my code which is quite different now. Feel free to pick only the changes you like instead of accepting the entire PR, especially since this is not tested code.